### PR TITLE
Yahoo Oauth API EOL

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -62,9 +62,9 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'       => $user['sub'],
             'nickname' => $user['nickname'],
-            'name'     => trim(sprintf('%s %s', Arr::get($user, 'givenName'), Arr::get($user, 'familyName'))),
-            'email'    => $user['email'],
-            'avatar'   => $user['picture'],
+            'name'     => trim(sprintf('%s %s', Arr::get($user, 'given_name'), Arr::get($user, 'family_name'))),
+            'email'    => Arr::get($user, 'email'),
+            'avatar'   => Arr::get($user, 'picture'),
         ]);
     }
 

--- a/Provider.php
+++ b/Provider.php
@@ -24,7 +24,8 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         $this->scopes(['openid2']);
-        $this->with(['openid2_realm' => $this->redirectUrl]);
+        $parse_url = parse_url($this->redirectUrl);
+        $this->with(['openid2_realm' => $parse_url['scheme'] . '://' . $parse_url['host']]);
         return $this->buildAuthUrlFromBase('https://api.login.yahoo.com/oauth2/request_auth', $state);
     }
 


### PR DESCRIPTION
OpenID2 to OpenID Connect Migration
- scope 參數要加入openID2 
- params 增加 openid2_realm (應是指跟redirect_url同一個domain的意思)

Social Directory EOL
- API URI 要換成 https://api.login.yahoo.com/openid/v1/userinfo
- response JSON 的資料結構也有調整，要更改抓資料的key
